### PR TITLE
Fixing incorrect arguments parsing

### DIFF
--- a/run_cpd.sh
+++ b/run_cpd.sh
@@ -4,7 +4,7 @@
 cpd_args=""
 rm -f /tmp/list
 for (( i=1; i <= "$#"; i++ )); do
-    if [[ ${!i} =~ --?[^=]+=.* || ${!i} =~ --?[^=]+ ]]; then
+    if [[ ${!i} =~ ^[\ ]*--?[^=]+ ]]; then
       cpd_args="$cpd_args ${!i}"
     else
       echo "${!i}" >> /tmp/list

--- a/run_pmd.sh
+++ b/run_pmd.sh
@@ -4,7 +4,7 @@
 pc_args=""
 rm -f /tmp/list
 for (( i=1; i <= "$#"; i++ )); do
-    if [[ ${!i} =~ --?[^=]+=.* || ${!i} =~ --?[^=]+ ]]; then
+    if [[ ${!i} =~ ^[\ ]*--?[^=]+ ]]; then
       pc_args="$pc_args ${!i}"
     else
       echo "${!i}" >> /tmp/list


### PR DESCRIPTION
Paths with `-` (dashes) are treated as parameters.

I'm working with multi-module project, and the module directory has dash in its name (for example: `module-a/src/Main.java`), and files in them are parsed as PMD arguments.

Updated the regexp to look for dashes only at beginning of argument.  Added a space pattern at the beginning in case someone has them in args.  Also removed one of regexp because it is covered by second.
