### PR TITLE
pmd: The `format` parameter can now be overwritten.

### DIFF
--- a/run_pmd.sh
+++ b/run_pmd.sh
@@ -16,10 +16,15 @@ if [[ ! $pc_args == *"--use-version="* ]]; then
   pc_args="$pc_args --use-version=java-17"
 fi
 
+# add default format if not specified
+if [[ ! $pc_args == *"-f="* && ! $pc_args == *"--format="* ]]; then
+  pc_args="$pc_args -f=textcolor"
+fi
+
 # add default ruleset if not specified
 if [[ ! $pc_args == *"-R="* && ! $pc_args == *"--rulesets="* ]]; then
   pc_args="$pc_args -R=/opt/ruleset.xml"
 fi
 
 # shellcheck disable=SC2086
-/opt/pmd/bin/pmd check --no-progress -f=textcolor --file-list=/tmp/list $pc_args
+/opt/pmd/bin/pmd check --no-progress --file-list=/tmp/list $pc_args


### PR DESCRIPTION
When you commit in an IDE (Visual Studio Code) you get this output:

![image](https://github.com/user-attachments/assets/c09e63f7-006a-4627-9071-d2a9bff49630)

If you are developing in a larger team, not everyone will be using the git CLI, so it is better to change the format to `text` instead of `textcolour`.

![image](https://github.com/user-attachments/assets/f9acb691-809f-4ea0-af72-7b8a1bffe83f)