### PR TITLE
Fixed update script for PMD

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-pmd_current=$(curl --silent https://api.github.com/repos/pmd/pmd/releases/latest | jq '.assets[] | select(.name | contains("pmd-dist-") and contains("-bin.zip")) | .browser_download_url' | sed -e 's/^"//' -e 's/"$//')
+pmd_current=$(curl --silent https://api.github.com/repos/pmd/pmd/releases/latest | jq -r '.assets[] | select(.name | test("pmd-dist-.+-bin.zip$")) | .browser_download_url')
 sed -i -e "s|PMD_RELEASE=.*|PMD_RELEASE=\"$pmd_current\"|g" install.sh
 
-checkstyle_current=$(curl --silent https://api.github.com/repos/checkstyle/checkstyle/releases/latest | jq '.assets[] | select(.name | contains("checkstyle-") and contains(".jar")) | .browser_download_url' | sed -e 's/^"//' -e 's/"$//')
+checkstyle_current=$(curl --silent https://api.github.com/repos/checkstyle/checkstyle/releases/latest | jq -r '.assets[] | select(.name | test("checkstyle-.+.jar$")) | .browser_download_url')
 sed -i -e "s|CHECKSTYLE_RELEASE=.*|CHECKSTYLE_RELEASE=\"$checkstyle_current\"|g" install.sh


### PR DESCRIPTION
Starting from [PMD 7.11.0](https://github.com/pmd/pmd/commit/dd54ddf5062f7f56afe589b7ac6043f253d006f9), assets are now [signed](https://github.com/pmd/pmd/releases/tag/pmd_releases%2F7.11.0#signed-releases), which broke the PMD [update script](https://github.com/gherynos/pre-commit-java/actions/runs/13614143779/job/38055017070).

The script was finding more than one asset (`pmd-dist-VERSION-bin.zip` and `pmd-dist-VERSION-bin.zip.asc`). To address this, I replaced the `contains` check with a `test (regexp) to ensure the correct asset is selected. Additionally, I updated the Checkstyle script in the same manner as a precautionary measure.

I also think adding a manual run option for the workflow could be a good idea. This would allow us to trigger the update process on demand when needed.